### PR TITLE
feat: use /tmp/runrs.db as default database instead of in memory

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,7 +3,7 @@
 export RUST_LIB_BACKTRACE=1
 export RUST_LOG=error,runrs=debug
 
-export CONFIG_PATH="/tmp/config.toml"
+export CONFIG_PATH="$HOME/.gitlab-runner/config.toml"
 export SECRET="warblgarbl"
 
 export LOG_FMT=plain


### PR DESCRIPTION
The in-memory database is okay for tests, but it is too unstable for development use (at least on my machine). This implements using a file at `/tmp/runrs.db` instead by default.