### PR TITLE
feat: fully nixify CI to benefit from cacheing

### DIFF
--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -5,27 +5,14 @@ on:
     branches: [ "main" ]
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --check --all
-      - run: cargo clippy --all-targets --no-deps -- --deny warnings --deny clippy::all
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo nextest run --workspace --cargo-profile release
-        env:
-          RUST_BACKTRACE: 1
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Lint, test and build the crate
+        run: nix --print-build-logs build
 
   typos:
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,14 @@
       flake-utils,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
+    let
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+    in
+    flake-utils.lib.eachSystem supportedSystems (
       system:
       let
         overlays = [ (import rust-overlay) ];
@@ -59,6 +66,8 @@
             # This switches rustfmt to the nightly channel.
             rust-bin.nightly.latest.rustfmt
           ];
+
+          cargoTestExtraArgs = "--workspace";
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -75,7 +84,7 @@
           }
         );
 
-        runrs-nextest = craneLib.cargoNextest (commonArgs // { inherit cargoArtifacts; });
+        runrs-test = craneLib.cargoTest (commonArgs // { inherit cargoArtifacts; });
 
         runrs-docker-image = pkgs.dockerTools.buildLayeredImage {
           name = "ghcr.io/bmc-labs/runrs";
@@ -124,7 +133,7 @@
             runrs
             runrs-fmt
             runrs-clippy
-            runrs-nextest
+            runrs-test
             ;
         };
 


### PR DESCRIPTION
Until now, we've been using canonical `cargo` commands for builds in PRs. This switches everything to nix.

The reason we hadn't switched before was that I hadn't figured out how to print full logs with nix. This is now achieved via `--print-build-logs`, which in retrospect seems too easy to be hard to figure out - not an uncommon feeling when working with nix, and not an excuse per se, but alas, here we are.

This means that builds in PRs should now create the cache for builds on main, such that we won't need to fully build the crate on main any longer - just the Docker image.