### PR TITLE
feat: Map GitLab Runner Docker Parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -62,13 +62,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sqlx",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -219,14 +219,14 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -287,9 +287,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -317,15 +317,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 
 [[package]]
 name = "cfg-if"
@@ -343,7 +343,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -462,9 +462,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
 ]
@@ -509,12 +509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
-name = "finl_unicode"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +526,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -647,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glrcfg"
@@ -662,6 +656,7 @@ dependencies = [
  "proptest",
  "regex",
  "serde",
+ "serde_json",
  "sqlx",
  "test-strategy",
  "thiserror",
@@ -793,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
@@ -803,12 +798,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -816,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -828,9 +823,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -848,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-util",
@@ -858,7 +853,6 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
  "tokio",
 ]
 
@@ -919,15 +913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,11 +944,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -1007,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchers"
@@ -1038,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
@@ -1082,7 +1067,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1093,7 +1078,7 @@ checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1104,9 +1089,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -1120,9 +1105,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1169,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1242,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1269,9 +1254,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1285,9 +1270,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1338,7 +1323,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1443,13 +1428,13 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1520,11 +1505,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1535,8 +1520,8 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1550,13 +1535,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1567,9 +1552,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "ring"
@@ -1581,7 +1566,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1638,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -1649,22 +1634,22 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.69",
+ "syn 2.0.71",
  "walkdir",
 ]
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.4.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1682,7 +1667,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1770,29 +1755,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -1925,12 +1910,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -1950,11 +1929,10 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
+checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
 dependencies = [
- "itertools",
  "nom",
  "unicode_categories",
 ]
@@ -2063,7 +2041,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -2107,7 +2085,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "chrono",
  "crc",
@@ -2166,13 +2144,13 @@ dependencies = [
 
 [[package]]
 name = "stringprep"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
 dependencies = [
- "finl_unicode",
  "unicode-bidi",
  "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -2184,7 +2162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2195,14 +2173,14 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
@@ -2238,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2290,7 +2268,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2306,22 +2284,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2367,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2382,9 +2360,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2401,13 +2379,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2436,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e43f8cc456c9704c851ae29c67e17ef65d2c30017c17a9765b89c382dc8bba"
+checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2457,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.13"
+version = "0.22.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
+checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
 dependencies = [
  "indexmap",
  "serde",
@@ -2516,7 +2494,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2575,11 +2553,10 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
- "lazy_static",
  "tracing-core",
  "tracing-subscriber",
  "tracing-test-macro",
@@ -2587,13 +2564,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
- "lazy_static",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2645,6 +2621,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,9 +2634,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode_categories"
@@ -2708,7 +2690,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.69",
+ "syn 2.0.71",
  "url",
  "uuid",
 ]
@@ -2731,9 +2713,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "rand",
@@ -2810,7 +2792,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -2832,7 +2814,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2896,7 +2878,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2914,7 +2896,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2934,18 +2916,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2956,9 +2938,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2968,9 +2950,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2980,15 +2962,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2998,9 +2980,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3010,9 +2992,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3022,9 +3004,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3034,15 +3016,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
 ]
@@ -3055,29 +3037,29 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glrcfg"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,6 @@ name = "glrcfg"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "indexmap",
  "indoc",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ name = "glrcfg"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "indexmap",
  "indoc",
  "once_cell",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ chrono = { version = "0.4.38", features = [
     "now",
     "std",
 ], default-features = false }
-glrcfg = { version = "0.1.0", path = "glrcfg", features = ["tracing", "sqlx"] }
+glrcfg = { version = "0.2.0", path = "glrcfg", features = ["tracing", "sqlx"] }
 jsonwebtoken = "9.2.0"
 miette = { version = "7.2.0", features = ["fancy"] }
 mime = "0.3.17"

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.113"
 sqlx = { version = "0.7.4", default-features = false, optional = true }
 thiserror = "1.0.61"
 toml = "0.8.12"

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -23,7 +23,6 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }
-serde_json = "1.0.113"
 sqlx = { version = "0.7.4", default-features = false, optional = true }
 thiserror = "1.0.61"
 toml = "0.8.12"
@@ -39,5 +38,6 @@ sqlx = ["dep:sqlx"]
 indoc = "2.0.5"
 pretty_assertions = "1.4.0"
 proptest = "1.5.0"
+serde_json = "1.0.120"
 test-strategy = "0.4.0"
 toml = "0.8.12"

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -19,7 +19,6 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "now",
     "std",
 ] }
-indexmap = { version = "2.2.6", features = ["serde"] }
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "now",
     "std",
 ] }
+indexmap = { version = "2.2.6", features = ["serde"] }
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -3,7 +3,7 @@ name = "glrcfg"
 description = "A Rust implementation of the GitLab Runner Advanced Configuration file format"
 readme = "README.md"
 
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -11,7 +11,10 @@ repository.workspace = true
 keywords = ["gitlab", "runner", "runners", "configuration", "config"]
 exclude = [".github"]
 
-authors = ["Florian Eich <florian.eich@bmc-labs.com>"]
+authors = [
+    "Florian Eich <florian.eich@bmc-labs.com>",
+    "Fabio Meier <fabio.meier@bmc-labs.com>",
+]
 
 [dependencies]
 chrono = { version = "0.4.38", default-features = false, features = [

--- a/glrcfg/src/global.rs
+++ b/glrcfg/src/global.rs
@@ -11,7 +11,7 @@ use url::Url;
 static GOLANG_DURATION_REGEX_STR: &str = r"([+-]?(\d+(h|m|s|ms|us|µs|ns))+|0)";
 static GOLANG_DURATION_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(r"^{GOLANG_DURATION_REGEX_STR}$"))
-        .expect("unable to instantiate GOLANG_DURATION_REGEX from given static string")
+        .expect("instantiating GOLANG_DURATION_REGEX from given static string must not fail")
 });
 
 /// Defines the log level. Options are `debug`, `info`, `warn`, `error`, `fatal`, and `panic`. This
@@ -59,6 +59,7 @@ pub struct GolangDurationParseError;
 /// # use glrcfg::GolangDuration;
 /// let duration = GolangDuration::parse("15m").unwrap();
 /// assert_eq!(duration.as_str(), "15m");
+/// assert!(GolangDuration::parse("42hours").is_err());
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
@@ -163,14 +164,14 @@ mod test {
     }
 
     #[proptest]
-    fn parse_valid_golang_durations(#[strategy(GOLANG_DURATION_REGEX_STR)] token: String) {
-        assert_eq!(token, GolangDuration::parse(&token).unwrap().as_str());
+    fn parse_valid_golang_durations(#[strategy(GOLANG_DURATION_REGEX_STR)] duration: String) {
+        assert_eq!(duration, GolangDuration::parse(&duration).unwrap().as_str());
     }
 
     #[proptest]
     fn parse_invalid_golang_durations(
-        #[filter(|t| !GOLANG_DURATION_REGEX.is_match(t))] token: String,
+        #[filter(|s| !GOLANG_DURATION_REGEX.is_match(s))] duration: String,
     ) {
-        assert!(GolangDuration::parse(token).is_err());
+        assert!(GolangDuration::parse(duration).is_err());
     }
 }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -18,13 +18,13 @@ pub struct Docker {
     pub allowed_pull_policies: Vec<String>,
     pub allowed_services: Vec<String>,
     pub allowed_privileged_services: Vec<String>,
-    pub cache_dir: String,
+    pub cache_dir: Option<String>,
     pub cap_add: Vec<String>,
     pub cap_drop: Vec<String>,
-    pub cpuset_cpus: String,
-    pub cpuset_mems: String,
+    pub cpuset_cpus: Option<String>,
+    pub cpuset_mems: Option<String>,
     pub cpu_shares: u32,
-    pub cpus: String,
+    pub cpus: Option<String>,
     pub devices: Vec<String>,
     pub device_cgroup_rules: Vec<String>, // https://docs.docker.com/compose/compose-file/05-services/#device_cgroup_rules
     pub disable_cache: bool,              // written in cli runner creation
@@ -42,9 +42,9 @@ pub struct Docker {
     pub hostname: Option<String>,
     pub image: String, // written in cli runner creation
     pub links: Vec<String>,
-    pub memory: String,
-    pub memory_swap: String,
-    pub memory_reservation: String,
+    pub memory: Option<String>,
+    pub memory_swap: Option<String>,
+    pub memory_reservation: Option<String>,
     pub network_mode: Option<String>,
     pub network_mtu: u32, // written in cli runner creation, not in gitlab runner docs
     pub mac_adress: Option<String>,
@@ -55,7 +55,7 @@ pub struct Docker {
     pub runtime: Option<String>,
     pub isolation: Option<String>,
     pub security_opt: Vec<String>, // todo: serialization needs to use a : instead of the , between elements
-    pub shm_size: u32,
+    pub shm_size: Option<u32>,
     pub smg_size: u32, // written in cli runner creation, not in gitlub runner docs
     pub sysctls: Option<Sysctls>, // todo: Implement Sysctls
     pub tls_cert_path: Option<String>,
@@ -78,13 +78,13 @@ impl Default for Docker {
             allowed_pull_policies: Vec::new(),
             allowed_services: Vec::new(),
             allowed_privileged_services: Vec::new(),
-            cache_dir: "".to_string(), // value from example
+            cache_dir: None,
             cap_add: Vec::new(),
             cap_drop: Vec::new(),
-            cpuset_cpus: "0,1".to_string(), // value from example
-            cpuset_mems: "0,1".to_string(), // value from example
-            cpu_shares: 1024,
-            cpus: "2".to_string(), // value from example
+            cpuset_cpus: None,
+            cpuset_mems: None,
+            cpu_shares: 1024, // default value as read in the gitlab docs
+            cpus: None,
             devices: Vec::new(),
             device_cgroup_rules: Vec::new(),
             disable_cache: false,
@@ -101,9 +101,9 @@ impl Default for Docker {
             hostname: None,
             image: "alpine:latest".to_string(),
             links: Vec::new(),
-            memory: "128m".to_string(),            // value from example
-            memory_swap: "256m".to_string(),       // value from example
-            memory_reservation: "64m".to_string(), // value from example
+            memory: None,
+            memory_swap: None,
+            memory_reservation: None,
             network_mode: None,
             network_mtu: 0,
             mac_adress: None,
@@ -114,17 +114,17 @@ impl Default for Docker {
             runtime: None,
             isolation: None,
             security_opt: Vec::new(),
-            shm_size: 300000, // value from example
+            shm_size: None,
             smg_size: 0,
             sysctls: None,
             tls_cert_path: None,
-            tls_verify: false,
+            tls_verify: false, // default value as read in the gitlab docs
             user: None,
             userns_mode: None,
             volumes: stringvec!["/cache"],
             volumes_from: Vec::new(),
             volume_driver: None,
-            wait_for_service_timeout: 30,
+            wait_for_service_timeout: 30, // default value as read in the gitlab docs
             container_labels: Vec::new(),
             services: Vec::new(),
         }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -147,7 +147,7 @@ pub struct Docker {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub container_labels: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub services: Vec<Services>,
+    pub services: Vec<Service>,
 }
 
 impl Default for Docker {
@@ -221,7 +221,7 @@ pub struct Sysctls {}
 /// Each service runs in a separate container and is linked to the job.
 /// Further documentation found in the [GitLab Docs](https://archives.docs.gitlab.com/15.11/runner/configuration/advanced-configuration.html#the-runnersdockerservices-section)
 #[derive(Debug, Serialize)]
-pub struct Services {
+pub struct Service {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -1,5 +1,4 @@
 // Copyright 2024 bmc::labs GmbH. All rights reserved.
-
 use serde::Serialize;
 
 macro_rules! stringvec {
@@ -13,32 +12,134 @@ macro_rules! stringvec {
 /// docs](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section).
 #[derive(Debug, Serialize)]
 pub struct Docker {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub allowed_images: Vec<String>,
+    pub allowed_privileged_images: Vec<String>,
+    pub allowed_pull_policies: Vec<String>,
+    pub allowed_services: Vec<String>,
+    pub allowed_privileged_services: Vec<String>,
+    pub cache_dir: String,
+    pub cap_add: Vec<String>,
+    pub cap_drop: Vec<String>,
+    pub cpuset_cpus: String,
+    pub cpuset_mems: String,
+    pub cpu_shares: u32,
+    pub cpus: String,
+    pub devices: Vec<String>,
+    pub device_cgroup_rules: Vec<String>, // https://docs.docker.com/compose/compose-file/05-services/#device_cgroup_rules
+    pub disable_cache: bool,              // written in cli runner creation
+    pub disable_entrypoint_overwrite: bool, // written in cli runner creation
+    pub dns: Vec<String>,
+    pub dns_search: Vec<String>,
+    pub extra_hosts: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_images: Option<String>,
-    pub disable_cache: bool,
-    pub disable_entrypoint_overwrite: bool,
-    pub image: String,
-    pub network_mtu: u32,
-    pub oom_kill_disable: bool,
-    pub privileged: bool,
-    pub smg_size: u32,
-    pub tls_verify: bool,
-    pub volumes: Vec<String>,
+    pub gpus: Option<String>,
+    pub group_add: Vec<String>,
+    pub helper_image: Option<String>,
+    pub helper_image_flavor: Option<String>,
+    pub helper_image_autoset_arch_and_os: Option<String>,
+    pub host: Option<String>,
+    pub hostname: Option<String>,
+    pub image: String, // written in cli runner creation
+    pub links: Vec<String>,
+    pub memory: String,
+    pub memory_swap: String,
+    pub memory_reservation: String,
+    pub network_mode: Option<String>,
+    pub network_mtu: u32, // written in cli runner creation, not in gitlab runner docs
+    pub mac_adress: Option<String>,
+    pub oom_kill_disable: bool, // written in cli runner creation
+    pub oom_score_adjust: Option<i32>,
+    pub privileged: bool, // written in cli runner creation
+    pub pull_policy: Vec<String>,
+    pub runtime: Option<String>,
+    pub isolation: Option<String>,
+    pub security_opt: Vec<String>, // todo: serialization needs to use a : instead of the , between elements
+    pub shm_size: u32,
+    pub smg_size: u32, // written in cli runner creation, not in gitlub runner docs
+    pub sysctls: Option<Sysctls>, // todo: Implement Sysctls
+    pub tls_cert_path: Option<String>,
+    pub tls_verify: bool, // written in cli runner creation
+    pub user: Option<String>,
+    pub userns_mode: Option<String>,
+    pub volumes: Vec<String>, // written in cli runner creation
+    pub volumes_from: Vec<String>,
+    pub volume_driver: Option<String>,
+    pub wait_for_service_timeout: u32,
+    pub container_labels: Vec<String>,
+    pub services: Vec<Services>,
 }
 
 impl Default for Docker {
     fn default() -> Self {
         Self {
-            allowed_images: None,
+            allowed_images: Vec::new(),
+            allowed_privileged_images: Vec::new(),
+            allowed_pull_policies: Vec::new(),
+            allowed_services: Vec::new(),
+            allowed_privileged_services: Vec::new(),
+            cache_dir: "".to_string(), // value from example
+            cap_add: Vec::new(),
+            cap_drop: Vec::new(),
+            cpuset_cpus: "0,1".to_string(), // value from example
+            cpuset_mems: "0,1".to_string(), // value from example
+            cpu_shares: 1024,
+            cpus: "2".to_string(), // value from example
+            devices: Vec::new(),
+            device_cgroup_rules: Vec::new(),
             disable_cache: false,
             disable_entrypoint_overwrite: false,
+            dns: Vec::new(),
+            dns_search: Vec::new(),
+            extra_hosts: Vec::new(),
+            gpus: None,
+            group_add: Vec::new(),
+            helper_image: None,
+            helper_image_flavor: None,
+            helper_image_autoset_arch_and_os: None,
+            host: None,
+            hostname: None,
             image: "alpine:latest".to_string(),
+            links: Vec::new(),
+            memory: "128m".to_string(),            // value from example
+            memory_swap: "256m".to_string(),       // value from example
+            memory_reservation: "64m".to_string(), // value from example
+            network_mode: None,
             network_mtu: 0,
+            mac_adress: None,
             oom_kill_disable: false,
+            oom_score_adjust: None,
             privileged: false,
+            pull_policy: vec!["always".to_string()], // Default would be "always" as string. Multiple policies are defined as list.
+            runtime: None,
+            isolation: None,
+            security_opt: Vec::new(),
+            shm_size: 300000, // value from example
             smg_size: 0,
+            sysctls: None,
+            tls_cert_path: None,
             tls_verify: false,
+            user: None,
+            userns_mode: None,
             volumes: stringvec!["/cache"],
+            volumes_from: Vec::new(),
+            volume_driver: None,
+            wait_for_service_timeout: 30,
+            container_labels: Vec::new(),
+            services: Vec::new(),
         }
     }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Sysctls {}
+
+#[derive(Debug, Serialize)]
+pub struct Services {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    pub entrypoint: Option<String>,
+    pub command: Option<String>,
+    pub environment: Option<Vec<String>>,
 }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -210,3 +210,22 @@ impl Serialize for SecurityOpt {
         serializer.serialize_str(&s)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use serde_json;
+    use pretty_assertions::assert_eq;
+
+    use super::SecurityOpt;
+
+    #[test]
+    fn security_opt_serialization() {
+        let opt = SecurityOpt {
+            key: "warbl".to_string(),
+            value: "garbl".to_string(),
+        };
+
+        let serialized = serde_json::to_string(&opt).unwrap();
+        assert_eq!(serialized, "\"warbl:garbl\"");
+    }
+}

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -14,59 +14,101 @@ macro_rules! stringvec {
 pub struct Docker {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allowed_images: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allowed_privileged_images: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allowed_pull_policies: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allowed_services: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub allowed_privileged_services: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_dir: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cap_add: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub cap_drop: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_cpus: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset_mems: Option<String>,
     pub cpu_shares: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpus: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub devices: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub device_cgroup_rules: Vec<String>, // https://docs.docker.com/compose/compose-file/05-services/#device_cgroup_rules
     pub disable_cache: bool,              // written in cli runner creation
     pub disable_entrypoint_overwrite: bool, // written in cli runner creation
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dns: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dns_search: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_hosts: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gpus: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub group_add: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub helper_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub helper_image_flavor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub helper_image_autoset_arch_and_os: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
     pub image: String, // written in cli runner creation
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_swap: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memory_reservation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network_mode: Option<String>,
     pub network_mtu: u32, // written in cli runner creation, not in gitlab runner docs
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
     pub oom_kill_disable: bool, // written in cli runner creation
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_score_adjust: Option<i32>,
     pub privileged: bool, // written in cli runner creation
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pull_policy: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub security_opt: Vec<String>, // todo: serialization needs to use a : instead of the , between elements
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<u32>,
     pub smg_size: u32, // written in cli runner creation, not in gitlub runner docs
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<Sysctls>, // todo: Implement Sysctls
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_cert_path: Option<String>,
     pub tls_verify: bool, // written in cli runner creation
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub userns_mode: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub volumes: Vec<String>, // written in cli runner creation
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub volumes_from: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub volume_driver: Option<String>,
     pub wait_for_service_timeout: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub container_labels: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub services: Vec<Services>,
 }
 
@@ -145,7 +187,10 @@ pub struct Services {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<Vec<String>>,
 }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -1,5 +1,5 @@
 // Copyright 2024 bmc::labs GmbH. All rights reserved.
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 macro_rules! stringvec {
     ($($x:expr),*) => (vec![$($x.to_string()),*]);
@@ -86,7 +86,7 @@ pub struct Docker {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub security_opt: Vec<String>, // todo: serialization needs to use a : instead of the , between elements
+    pub security_opt: Vec<SecurityOpt>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<u32>,
     pub smg_size: u32, // written in cli runner creation, not in gitlub runner docs
@@ -193,4 +193,20 @@ pub struct Services {
     pub command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+pub struct SecurityOpt {
+    pub key: String,
+    pub value: String,
+}
+
+impl Serialize for SecurityOpt {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}:{}", self.key, self.value);
+        serializer.serialize_str(&s)
+    }
 }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -10,7 +10,7 @@ macro_rules! stringvec {
 /// or any container runtime configured inside a job, does not inherit these parameters.
 ///
 /// Further documentation found in [the GitLab
-/// docs](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-global-section).
+/// docs](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section).
 #[derive(Debug, Serialize)]
 pub struct Docker {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -131,9 +131,15 @@ impl Default for Docker {
     }
 }
 
+/// sysctl options for docker
 #[derive(Debug, Serialize)]
 pub struct Sysctls {}
 
+/// Specify additional services that should be run with the job.
+///
+/// Visit the [Docker Registry](https://hub.docker.com/) for the list of available images.
+/// Each service runs in a separate container and is linked to the job.
+/// Further documentation found in the [GitLab Docs](https://archives.docs.gitlab.com/15.11/runner/configuration/advanced-configuration.html#the-runnersdockerservices-section)
 #[derive(Debug, Serialize)]
 pub struct Services {
     pub name: String,

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -47,7 +47,7 @@ pub struct Docker {
     pub memory_reservation: Option<String>,
     pub network_mode: Option<String>,
     pub network_mtu: u32, // written in cli runner creation, not in gitlab runner docs
-    pub mac_adress: Option<String>,
+    pub mac_address: Option<String>,
     pub oom_kill_disable: bool, // written in cli runner creation
     pub oom_score_adjust: Option<i32>,
     pub privileged: bool, // written in cli runner creation
@@ -106,7 +106,7 @@ impl Default for Docker {
             memory_reservation: None,
             network_mode: None,
             network_mtu: 0,
-            mac_adress: None,
+            mac_address: None,
             oom_kill_disable: false,
             oom_score_adjust: None,
             privileged: false,

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -39,7 +39,7 @@ pub struct Docker {
     pub devices: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub device_cgroup_rules: Vec<String>, // https://docs.docker.com/compose/compose-file/05-services/#device_cgroup_rules
-    pub disable_cache: bool,              // written in cli runner creation
+    pub disable_cache: bool,                // written in cli runner creation
     pub disable_entrypoint_overwrite: bool, // written in cli runner creation
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub dns: Vec<String>,

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::{Docker, PullPolicy, SecurityOpt, Services, Sysctls};
+pub use docker::{Docker, OptionSet, SecurityOpt, Services, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::Docker;
+pub use docker::{Docker, Services, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::{Docker, OptionSet, SecurityOpt, Service, Sysctls};
+pub use docker::{Docker, MaybeMultiple, PullPolicy, SecurityOpt, Service, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::{Docker, OptionSet, SecurityOpt, Services, Sysctls};
+pub use docker::{Docker, OptionSet, SecurityOpt, Service, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.
@@ -16,11 +16,16 @@ use serde::Serialize;
 /// intentional. The executor `docker-windows` is on the roadmap, both `parallels` and `virtualbox`
 /// are still up for debate. We don't plan to ever support `docker+machine`, since the underlying
 /// technology - "Docker Machine" - is deprecated.
+//
+// This `#[allow]` turning off the clippy warning for large size differences between enum variants
+// is needed because `Docker` is huge, but using `Box<Docker>` would mean that users would have to
+// call `Box::new(docker)` with their config, which isn't exactly ergonomic.
+//
+// TODO(@florian): When other variants are added, check if the clippy warning can be turned back on.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize)]
 #[serde(tag = "executor", rename_all = "lowercase")]
 pub enum Executor {
     Shell,
     Docker { docker: Docker },
-    Ssh,
-    Kubernetes,
 }

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::{Docker, Services, Sysctls};
+pub use docker::{Docker, PullPolicy, SecurityOpt, Services, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor, PullPolicy, SecurityOpt, Services, Sysctls};
+pub use executors::{Docker, Executor, OptionSet, SecurityOpt, Services, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor};
+pub use executors::{Docker, Executor, Services, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor, OptionSet, SecurityOpt, Service, Sysctls};
+pub use executors::{Docker, Executor, MaybeMultiple, PullPolicy, SecurityOpt, Service, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor, OptionSet, SecurityOpt, Services, Sysctls};
+pub use executors::{Docker, Executor, OptionSet, SecurityOpt, Service, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor, Services, Sysctls};
+pub use executors::{Docker, Executor, PullPolicy, SecurityOpt, Services, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;

--- a/glrcfg/src/runner/runner_token.rs
+++ b/glrcfg/src/runner/runner_token.rs
@@ -10,11 +10,11 @@ use thiserror::Error;
 static RUNNER_TOKEN_REGEX_STR: &str = r"glrt-\w{20}";
 static RUNNER_TOKEN_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!("^{RUNNER_TOKEN_REGEX_STR}$"))
-        .expect("unable to instantiate RUNNER_TOKEN_REGEX from given static string")
+        .expect("instantiating RUNNER_TOKEN_REGEX from given static string must not fail")
 });
 
 #[derive(Debug, PartialEq, Eq, Error)]
-#[error("invalid runner token")]
+#[error("invalid runner token; must look like glrt-0123456789_abcdefXYZ")]
 pub struct RunnerTokenParseError;
 
 /// GitLab uses various kinds of tokens for authentication. When registering a runner via the
@@ -32,6 +32,7 @@ pub struct RunnerTokenParseError;
 /// # use glrcfg::runner::RunnerToken;
 /// let runner_token = RunnerToken::parse("glrt-0123456789_abcdefXYZ").unwrap();
 /// assert_eq!(runner_token.as_str(), "glrt-0123456789_abcdefXYZ");
+/// assert!(RunnerToken::parse("warblgarbl").is_err());
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]


### PR DESCRIPTION
We are currently only exposing a minimal set of adjustable parameters to the REST API of runnrs. In an effort to prepare for advanced use-cases this PR maps all available Docker Executor parameters of the GitLab documentation to the glrcfg. 

[GitLab Runners Docker Section](https://archives.docs.gitlab.com/15.11/runner/configuration/advanced-configuration.html#the-runnersdocker-section)

We implement all types according to the specifications in the documentation. For parameters whose default is explicitly specified, it is taken over. 
