### PR TITLE
feat: use UUIDs for GitLab Runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "runrs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "atmosphere",
  "axum",
@@ -2012,6 +2012,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots",
 ]
 
@@ -2094,6 +2095,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2133,6 +2135,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -2158,6 +2161,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -2732,6 +2736,7 @@ checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "glrcfg"]
 description = "A microservice to manage GitLab Runners in Docker via REST"
 readme = "README.md"
 
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -57,7 +57,13 @@ mime = "0.3.17"
 names = { version = "0.14.0", default-features = false }
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
-sqlx = { version = "0.7.3", features = ["runtime-tokio", "sqlite", "migrate"] }
+sqlx = { version = "0.7.3", features = [
+    "runtime-tokio",
+    "sqlite",
+    "migrate",
+    "chrono",
+    "uuid",
+] }
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full"] }
 toml = "0.8.12"
@@ -71,6 +77,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 tracing-test = "0.2.4"
 utoipa = { version = "4.2.0", features = ["axum_extras", "url"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
+uuid = { version = "1.8.0", features = ["v4", "serde"] }
 
 [dev-dependencies]
 http-body-util = "0.1.0"

--- a/migrations/20240203134208_gitlab_runners.up.sql
+++ b/migrations/20240203134208_gitlab_runners.up.sql
@@ -1,7 +1,8 @@
 -- Copyright 2024 bmc::labs GmbH. All rights reserved.
 
 CREATE TABLE IF NOT EXISTS gitlab_runners (
-    id                INTEGER PRIMARY KEY,
+    uuid              BLOB    PRIMARY KEY,
+    id                INTEGER NOT NULL,
     name              TEXT    NOT NULL,
     url               TEXT    NOT NULL,
     token             TEXT    NOT NULL,


### PR DESCRIPTION
Until now, our `GitLabRunner` used the `id` field as primary key in the database, with the additional constraint `UNIQUE(id, url, token)` because runner IDs are actually only unique per GitLab instance and each token can only be used once per GitLab instance as well. There is an obvious issue with that:

If the `id` is `PRIMARY KEY`, it is also `UNIQUE`, rendering the constraint `UNIQUE(id, url, token)` meaningless. Furthermore, as a result, we would never be able to store two runners with the same `id`, even though it is perfectly fine to have two such runners as long as they are not connected to the same GitLab instance.

This change fixes that by introducing a synthetic primary key in the form of a UUID. The `UNIQUE(id, url, token)` is kept in place because it is semantically correct: any GitLab instance generates a new `(id, token)` combination for every runner.