### PR TITLE
fix: repairs the OpenAPI schema provided by runrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,6 +2710,7 @@ dependencies = [
  "regex",
  "syn 2.0.69",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "chrono",
 ] }
 tracing-test = "0.2.4"
-utoipa = { version = "4.2.0", features = ["axum_extras", "url"] }
+utoipa = { version = "4.2.0", features = ["axum_extras", "url", "uuid"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 

--- a/src/handlers/gitlab_runners.rs
+++ b/src/handlers/gitlab_runners.rs
@@ -68,9 +68,9 @@ pub async fn list(State(AppState { pool, .. }): State<AppState>) -> Result<Respo
 
 #[utoipa::path(
     get,
-    path = "/gitlab-runners/{id}",
+    path = "/gitlab-runners/{uuid}",
     params(
-        ("id" = u32, Path, description = "GitLabRunner ID")
+        ("uuid" = Uuid, Path, description = "GitLabRunner UUID")
     ),
     responses(
         (status = StatusCode::OK, description = "Read all GitLabRunners", body = GitLabRunner),
@@ -95,9 +95,9 @@ pub async fn read(
 
 #[utoipa::path(
     put,
-    path = "/gitlab-runners/{id}",
+    path = "/gitlab-runners/{uuid}",
     params(
-        ("id" = u32, Path, description = "GitLabRunner ID")
+        ("uuid" = Uuid, Path, description = "GitLab Runner UUID")
     ),
     request_body(
         content = GitLabRunner, description = "GitLabRunner to update", content_type = "application/json"
@@ -141,9 +141,9 @@ pub async fn update(
 
 #[utoipa::path(
     delete,
-    path = "/gitlab-runners/{id}",
+    path = "/gitlab-runners/{uuid}",
     params(
-        ("id" = u32, Path, description = "GitLabRunner ID")
+        ("uuid" = Uuid, Path, description = "GitLabRunner UUID")
     ),
     responses(
         (status = StatusCode::OK, description = "Deleted GitLabRunner", body = GitLabRunner),

--- a/src/models/gitlab_runner.rs
+++ b/src/models/gitlab_runner.rs
@@ -30,6 +30,7 @@ fn default_name() -> String {
 pub struct GitLabRunner {
     #[sql(pk)]
     #[serde(default = "Uuid::new_v4")]
+    #[schema(value_type = String, format = Uuid, example = "be924fdd-fb28-468c-8c70-1f0ed3af4485")]
     uuid: Uuid,
     /// ID of the runner within the GitLab instance; unique for that GitLab instance
     id: u32,


### PR DESCRIPTION
Previous PR and v0.4.0 breaks the OpenAPI schema provided by runrs. This is the fix.