### PR TITLE
feat: create a docker compose file and make it work

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,7 +3,8 @@
 export RUST_LIB_BACKTRACE=1
 export RUST_LOG=error,runrs=debug
 
-export CONFIG_PATH="$HOME/.gitlab-runner/config.toml"
+export DATABASE_URL="./tmp/database.sqlite"
+export CONFIG_PATH="./tmp/config.toml"
 export SECRET="warblgarbl"
 
 export LOG_FMT=plain

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ $RECYCLE.BIN/
 # nix
 .direnv
 result
+
+# /tmp is used as a temporary directory during development
+/tmp/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,7 +2469,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bytes",
  "http",
  "http-body",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1593,7 +1593,7 @@ dependencies = [
 
 [[package]]
 name = "runrs"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "atmosphere",
  "axum",
@@ -1613,6 +1613,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -2455,6 +2456,24 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
  "pin-project-lite",
  "tokio",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "glrcfg"]
 description = "A microservice to manage GitLab Runners in Docker via REST"
 readme = "README.md"
 
-version = "0.4.0"
+version = "0.6.0"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -67,6 +67,7 @@ sqlx = { version = "0.7.3", features = [
 thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["full"] }
 toml = "0.8.12"
+tower-http = { version = "0.5.2", features = ["trace", "timeout"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = [
     "env-filter",

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ nix build
 # to build the Docker image:
 nix build .#runrs-docker-image
 
-# after bulding the Docker image, you need to load it:
+# after building the Docker image, you need to load it:
 docker load < result
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ It's a vanilla Rust and `cargo` project, so if you have a recent (1.75+) Rust to
 you should be good. For testing end to end, you'll need:
 
 - Docker, which is going to be used as the executor for your runners, up and running, and
-- `gitlab-runner`, either installed and running locally or running in Docker. The docs for
-  installing it are [here](https://docs.gitlab.com/runner/install/osx.html).
+- [Docker Compose](https://docs.docker.com/compose/install/)
 
 It's _also_ a nixified project using a flake, so if you prefer to use that to build it, you can.
 Look at the `flake.nix` for current package targets. In that vein: there is also a
@@ -61,6 +60,10 @@ Look at the `flake.nix` for current package targets. In that vein: there is also
    ```bash
    git clone git@github.com:bmc-labs/runrs.git
    cd runrs
+   ```
+1. Use Docker Compose to run the `gitlab-runner` service with correct setup in Docker.
+   ```bash
+   docker compose up -d
    ```
 1. Build and run the thing.
    ```bash
@@ -77,6 +80,9 @@ nix build
 
 # to build the Docker image:
 nix build .#runrs-docker-image
+
+# after bulding the Docker image, you need to load it:
+docker load < result
 ```
 
 That's it. Make a PR with your changes and we'll talk about them.

--- a/compose-deploy.yml
+++ b/compose-deploy.yml
@@ -1,8 +1,19 @@
-# Deployment Setup: sync this file to the target server and run
+# Deployment Setup:
 #
-# `docker compose -f compose-deploy.yml up -d`
+# Make sure the environment variable `TOKEN_SECRET` is injected from your secrets in CI. Then,
+# running `docker compose -f compose-deploy.yml up -d` will deploy the latest runrs alongside
+# `gitlab-runner`. If you do so on a host where port 3000 is mapped through to be externally
+# accessible, you can then use the `peripheral` Terraform Provider[0] to create runners.
 #
-# and watch the logs.
+# If you set the environment variables
+#
+# - `DOCKER_HOST`
+# - `DOCKER_TLS_VERIFY`
+# - `DOCKER_CERT_PATH`
+#
+# before running the up command, you can deploy to a remote Docker host.
+#
+# [0]: https://registry.terraform.io/providers/bmc-labs/peripheral/latest/docs
 
 volumes:
   data:

--- a/compose-deploy.yml
+++ b/compose-deploy.yml
@@ -1,0 +1,30 @@
+# Deployment Setup: sync this file to the target server and run
+#
+# `docker compose -f compose-deploy.yml up -d`
+#
+# and watch the logs.
+
+volumes:
+  data:
+
+services:
+  gitlab-runner:
+    image: gitlab/gitlab-runner:latest
+    restart: always
+    volumes:
+      - data:/etc/gitlab-runner
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  runrs:
+    image: ghcr.io/bmc-labs/runrs:latest
+    restart: always
+    environment:
+      RUST_LOG: "error,runrs=warn"
+      LOG_FMT: "plain"
+      DATABASE_URL: "/etc/gitlab-runner/runrs.sqlite"
+      CONFIG_PATH: "/etc/gitlab-runner/config.toml"
+      SECRET: "${TOKEN_SECRET}"
+    ports:
+      - 3000:3000
+    volumes:
+      - data:/etc/gitlab-runner

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,8 @@
-# Development Setup: in the root directory,
+# Development Setup:
 #
-# - run `docker compose up`
-# - run `cargo run`
-#
-# and re-run `cargo run` whenever you've made changes.
+# In the root directory, run `docker compose up -d`. Then, work on the codebase and run `cargo run`
+# to test your changes. You can manually test creating runners by navigating to the Swagger UI, the
+# link to which is printed when you run `cargo run`.
 
 services:
   gitlab-runner:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+# Development Setup: in the root directory,
+#
+# - run `docker compose up`
+# - run `cargo run`
+#
+# and re-run `cargo run` whenever you've made changes.
+
+services:
+  gitlab-runner:
+    image: gitlab/gitlab-runner:latest
+    restart: always
+    volumes:
+      - ./tmp:/etc/gitlab-runner
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/flake.nix
+++ b/flake.nix
@@ -137,12 +137,14 @@
             ;
         };
 
-        devShells.default = pkgs.mkShell { inputsFrom = [ runrs ]; };
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ runrs ];
 
-        # devShells.default = craneLib.devShell {
-        #   inputsFrom = [ runrs ];
-        #   checks = self.checks.${system};
-        # };
+          packages = with pkgs; [
+            docker
+            docker-compose
+          ];
+        };
       }
     );
 }

--- a/glrcfg/src/runner/runner_token.rs
+++ b/glrcfg/src/runner/runner_token.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-static RUNNER_TOKEN_REGEX_STR: &str = r"glrt-\w{20}";
+static RUNNER_TOKEN_REGEX_STR: &str = r"glrt-[\w-]{20}"; // note the hyphen
 static RUNNER_TOKEN_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!("^{RUNNER_TOKEN_REGEX_STR}$"))
         .expect("instantiating RUNNER_TOKEN_REGEX from given static string must not fail")

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,8 +18,8 @@ use crate::{
     models,
 };
 
-pub const DEFAULT_DATABASE_URL: &str = "/tmp/runrs.db";
-pub const DEFAULT_CONFIG_PATH: &str = "/tmp/gitlab-runner/config.toml";
+pub const DEFAULT_DATABASE_URL: &str = "/etc/runrs/database.sqlite";
+pub const DEFAULT_CONFIG_PATH: &str = "/etc/gitlab-runner/config.toml";
 
 #[derive(OpenApi)]
 #[openapi(

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 // Copyright 2024 bmc::labs GmbH. All rights reserved.
 
-use std::{fs::File, path::PathBuf};
+use std::{fs::File, path::PathBuf, time::Duration};
 
 use axum::{
     middleware,
@@ -8,6 +8,7 @@ use axum::{
     Router,
 };
 use miette::IntoDiagnostic;
+use tower_http::{timeout::TimeoutLayer, trace::TraceLayer};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -18,8 +19,9 @@ use crate::{
     models,
 };
 
-pub const DEFAULT_DATABASE_URL: &str = "/etc/runrs/database.sqlite";
-pub const DEFAULT_CONFIG_PATH: &str = "/etc/gitlab-runner/config.toml";
+pub static DEFAULT_DATABASE_URL: &str = "/etc/runrs/database.sqlite";
+pub static DEFAULT_CONFIG_PATH: &str = "/etc/gitlab-runner/config.toml";
+pub static REQUEST_TIMEOUT_SECS: u64 = 15;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -66,6 +68,12 @@ pub async fn router(secret: String, app_state: AppState) -> Router {
                 )
                 .layer(middleware::from_fn_with_state(secret, authenticate)),
         )
+        .layer((
+            // outer tracing layer
+            TraceLayer::new_for_http(),
+            // set timeout for all requests
+            TimeoutLayer::new(Duration::from_secs(REQUEST_TIMEOUT_SECS)),
+        ))
         .with_state(app_state)
 }
 


### PR DESCRIPTION
Improvements to our developer experience: aside from some minor changes, it adds a Docker Compose file which allows you to run `docker compose up` in our project root and then `cargo run` to get runrs up and running.

You can perform a manual end-to-end test - from creating the runner in GitLab to spawning it in the cluster and having it phone home to register itself - with these changes.