### PR TITLE
feat: ensure that 'multiple' in MaybeMultiple are actually multiple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "indoc",
+ "nonempty",
  "once_cell",
  "pretty_assertions",
  "proptest",
@@ -1140,6 +1141,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ version = "0.2.0"
 dependencies = [
  "chrono",
  "indoc",
- "nonempty",
+ "maybe-multiple",
  "once_cell",
  "pretty_assertions",
  "proptest",
@@ -1013,6 +1013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "maybe-multiple"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d928daff6b11193e7221239f2df5b4ce5667e07c35052b5d050e7027af12662c"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,15 +1151,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nonempty"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2295,18 +2296,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -22,6 +22,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "now",
     "std",
 ] }
+nonempty = { version = "0.10.0", features = ["serialize"] }
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/glrcfg/Cargo.toml
+++ b/glrcfg/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
     "now",
     "std",
 ] }
-nonempty = { version = "0.10.0", features = ["serialize"] }
+maybe-multiple = { version = "0.1.0", features = ["serde"] }
 once_cell = "1.19.0"
 regex = { version = "1.10.5", features = ["use_std"] }
 serde = { version = "1.0.196", features = ["derive"] }

--- a/glrcfg/src/runner/executors/docker.rs
+++ b/glrcfg/src/runner/executors/docker.rs
@@ -2,7 +2,7 @@
 
 use std::{fmt, str::FromStr};
 
-use nonempty::NonEmpty;
+use maybe_multiple::MaybeMultiple;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -252,109 +252,6 @@ pub enum PullPolicy {
     Never,        // "never"
 }
 
-/// An [`Option`], with in addition to `None` and `Some(T)`, there is `Vec(Vec<T>)`.
-///
-/// As with a regular [`Option`], the default is `None`. There is also an [`MaybeMultiple::is_none()`]
-/// method. Other than that, the API of `MaybeMultiple` is clearly much more limited than that of
-/// [`Option`], since we only implement what we need for the library.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(untagged)]
-pub enum MaybeMultiple<T> {
-    None,
-    Some(T),
-    Multiple(NonEmpty<T>),
-}
-
-impl<T> MaybeMultiple<T> {
-    pub fn is_none(&self) -> bool {
-        matches!(self, Self::None)
-    }
-}
-
-impl<T> Default for MaybeMultiple<T> {
-    fn default() -> Self {
-        Self::None
-    }
-}
-
-/// Enables the following usage pattern:
-///
-/// ```rust
-/// # use glrcfg::runner::{Docker, PullPolicy, MaybeMultiple};
-/// let docker = Docker { pull_policy: PullPolicy::Always.into(), ..Default::default() };
-///
-/// assert_eq!(docker.pull_policy, MaybeMultiple::Some(PullPolicy::Always));
-/// ```
-impl From<PullPolicy> for MaybeMultiple<PullPolicy> {
-    fn from(pull_policy: PullPolicy) -> Self {
-        Self::Some(pull_policy)
-    }
-}
-
-/// Enables the following usage pattern:
-///
-/// ```rust
-/// # use glrcfg::runner::{Docker, PullPolicy, MaybeMultiple};
-/// use nonempty::nonempty;
-/// let docker = Docker {
-///     pull_policy: nonempty![PullPolicy::Always, PullPolicy::IfNotPresent].into(),
-///     ..Default::default()
-/// };
-///
-/// assert_eq!(
-///     docker.pull_policy,
-///     MaybeMultiple::Multiple(nonempty![PullPolicy::Always, PullPolicy::IfNotPresent])
-/// );
-/// ```
-impl From<NonEmpty<PullPolicy>> for MaybeMultiple<PullPolicy> {
-    fn from(pull_policies: NonEmpty<PullPolicy>) -> Self {
-        Self::Multiple(pull_policies)
-    }
-}
-
-/// Enables the following usage pattern:
-///
-/// ```rust
-/// # use glrcfg::runner::{Docker, PullPolicy, MaybeMultiple};
-/// # use nonempty::nonempty;
-/// let docker = Docker {
-///     pull_policy: vec![PullPolicy::Always, PullPolicy::IfNotPresent].into(),
-///     ..Default::default()
-/// };
-///
-/// assert_eq!(
-///     docker.pull_policy,
-///     MaybeMultiple::Multiple(nonempty![PullPolicy::Always, PullPolicy::IfNotPresent])
-/// );
-/// ```
-impl From<Vec<PullPolicy>> for MaybeMultiple<PullPolicy> {
-    fn from(mut v: Vec<PullPolicy>) -> Self {
-        match v.len() {
-            0 => Self::None,
-            1 => Self::Some(v.pop().expect("input vec has one element")),
-            _ => Self::Multiple(NonEmpty::from_vec(v).expect("input vec has multiple elements")),
-        }
-    }
-}
-
-/// Enables the following usage pattern:
-///
-/// ```rust
-/// # use glrcfg::runner::{Docker, PullPolicy, MaybeMultiple};
-/// let pull_policy: Vec<PullPolicy> = MaybeMultiple::from(PullPolicy::Always).into();
-///
-/// assert_eq!(pull_policy, vec![PullPolicy::Always]);
-/// ```
-impl From<MaybeMultiple<PullPolicy>> for Vec<PullPolicy> {
-    fn from(maybe_multiple: MaybeMultiple<PullPolicy>) -> Self {
-        match maybe_multiple {
-            MaybeMultiple::None => vec![],
-            MaybeMultiple::Some(v) => vec![v],
-            MaybeMultiple::Multiple(n) => n.into(),
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Error)]
 #[error("invalid security option; must be a key:value pair")]
 pub struct SecurityOptParseError;
@@ -486,7 +383,7 @@ mod test {
         let serialized = serde_json::to_string(&policy).unwrap();
         assert_eq!(serialized, r#""always""#);
 
-        let policy = MaybeMultiple::from(vec![PullPolicy::Always, PullPolicy::IfNotPresent]);
+        let policy = MaybeMultiple::from_vec(vec![PullPolicy::Always, PullPolicy::IfNotPresent]);
         let serialized = serde_json::to_string(&policy).unwrap();
         assert_eq!(serialized, r#"["always","if-not-present"]"#);
     }

--- a/glrcfg/src/runner/executors/mod.rs
+++ b/glrcfg/src/runner/executors/mod.rs
@@ -2,7 +2,7 @@
 
 mod docker;
 
-pub use docker::{Docker, MaybeMultiple, PullPolicy, SecurityOpt, Service, Sysctls};
+pub use docker::{Docker, PullPolicy, SecurityOpt, Service, Sysctls};
 use serde::Serialize;
 
 /// The following executors are available.

--- a/glrcfg/src/runner/mod.rs
+++ b/glrcfg/src/runner/mod.rs
@@ -6,7 +6,7 @@ mod runner_token;
 mod url;
 
 pub use date_time::DateTime;
-pub use executors::{Docker, Executor, MaybeMultiple, PullPolicy, SecurityOpt, Service, Sysctls};
+pub use executors::{Docker, Executor, PullPolicy, SecurityOpt, Service, Sysctls};
 pub use runner_token::{RunnerToken, RunnerTokenParseError};
 use serde::Serialize;
 pub use url::Url;


### PR DESCRIPTION
In our current implementation of `MaybeMultiple`, the `MaybeMultiple::Multiple` variant holds a `Vec`. That `Vec` could be empty or only contain one element, which is semantically equivalent to the `::None` and `::Some(T)` variants respectively.

This changes the `::Multiple` variant to hold a container that can only contain 2 or more elements.