### PR TITLE
feat: release on version change in Cargo.toml, deploy on release

### DIFF
--- a/.github/workflows/on_main.yaml
+++ b/.github/workflows/on_main.yaml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -12,3 +12,13 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build .#runrs-docker-image
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: manoadamro/rust-release@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -2,7 +2,7 @@ name: Checks
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -29,3 +29,16 @@ jobs:
         run: nix build .#runrs-docker-image && docker load < result
       - name: Push Docker image with release tag to ghcr.io
         run: docker push ${{ env.REGISTRY }}/bmc-labs/runrs:$(cat version)
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Deploy to Docker
+        run: |
+          export TOKEN_SECRET="${{ secrets.TOKEN_SECRET }}"
+          docker compose -f compose-deploy.yml up -d

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "runrs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atmosphere",
  "axum",
@@ -2292,18 +2292,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d171f59dbaa811dbbb1aee1e73db92ec2b122911a48e1390dfe327a821ddede"
+checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08be0f17bd307950653ce45db00cd31200d82b624b36e181337d9c7d92765b5"
+checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "glrcfg"]
 description = "A microservice to manage GitLab Runners in Docker via REST"
 readme = "README.md"
 
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/compose-deploy.yml
+++ b/compose-deploy.yml
@@ -5,13 +5,10 @@
 # `gitlab-runner`. If you do so on a host where port 3000 is mapped through to be externally
 # accessible, you can then use the `peripheral` Terraform Provider[0] to create runners.
 #
-# If you set the environment variables
-#
-# - `DOCKER_HOST`
-# - `DOCKER_TLS_VERIFY`
-# - `DOCKER_CERT_PATH`
-#
-# before running the up command, you can deploy to a remote Docker host.
+# If you set the environment variables `DOCKER_HOST` to an external Docker host (which should look
+# like `export DOCKER_HOST="ssh://user@external-docker-host"`, where `user` is in the `docker` group
+# or able to access Docker for another reason) before running the up command, you can deploy to that
+# remote Docker host.
 #
 # [0]: https://registry.terraform.io/providers/bmc-labs/peripheral/latest/docs
 
@@ -36,6 +33,6 @@ services:
       CONFIG_PATH: "/etc/gitlab-runner/config.toml"
       SECRET: "${TOKEN_SECRET}"
     ports:
-      - 3000:3000
+      - 80:3000
     volumes:
       - data:/etc/gitlab-runner


### PR DESCRIPTION
Aside from some minor fixes ("drive bys"), this

- adds an action which cuts a release whenever there's a new version in `Cargo.toml`
- adds a deploy step when a new release is cut