### PR TITLE
chore: set up releasing from CI

### DIFF
--- a/.github/workflows/on_main.yaml
+++ b/.github/workflows/on_main.yaml
@@ -15,3 +15,16 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix build .#runrs-docker-image
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ssh-key: "${{secrets.DEPLOY_KEY}}"
+      - uses: manoadamro/rust-release@v1
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "runrs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atmosphere",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "glrcfg"]
 description = "A microservice to manage GitLab Runners in Docker via REST"
 readme = "README.md"
 
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,9 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
-    crane = {
-      url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";
@@ -36,9 +32,9 @@
         pkgs = import nixpkgs { inherit system overlays; };
         inherit (pkgs) lib;
 
-        rustToolchain = pkgs.rust-bin.stable.latest.default;
         # alternatively, to use a rust-toolchain.toml - which we'll want once runrs becomes stable:
         # rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
 
         craneLib = (crane.mkLib nixpkgs.legacyPackages.${system}).overrideToolchain rustToolchain;
 


### PR DESCRIPTION
After previous attempts have failed due to how GitHub CI sequence works, this is another stab at setting up automated releasing after changing the version in `Cargo.toml`.