### PR TITLE
feat(defaults): connect host's Docker socket to runners by default

### DIFF
--- a/src/models/gitlab_runner.rs
+++ b/src/models/gitlab_runner.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
+macro_rules! stringvec {
+    ($($x:expr),*) => (vec![$($x.to_string()),*]);
+}
+
 fn default_name() -> String {
     let mut generator = Generator::with_naming(Name::Numbered);
     generator.next().unwrap_or_else(|| "usain-bolt".to_string())
@@ -69,6 +73,9 @@ impl From<GitLabRunner> for Runner {
             executor: Executor::Docker {
                 docker: Docker {
                     image: runner.docker_image,
+                    // connect the docker socket from the host into all runner containers, enabling
+                    // them to access the host's docker daemon for pulling and pushing images
+                    volumes: stringvec!["/var/run/docker.sock:/var/run/docker.sock", "/cache"],
                     ..Default::default()
                 },
             },


### PR DESCRIPTION
## 📝 Description

The `docker` command line tool needs access to the Docker daemon for certain tasks, amongst them the ability to log into and push images to a registry. This MR gives GitLab Runners access to the host's Docker daemon, which enables building and pushing Docker images in the runner.

This also decreases security. For now, we use `runrs` on isolated machines running Docker only for the purpose of having GitLab Runners, and as long as `runrs` isn't used to operate multi-tenant instances, this is a bearable compromise. For the future however, a different solution must be found.

## 🔗 Related Issue(s)

None.

## 🎯 Type of Change

- [ ] 🐛 Fix (non-breaking change)
- [x] ✨ Feature (non-breaking change)
- [ ] 💥 Breaking change (change breaks user facing API)
- [ ] 📚 Documentation update
- [ ] ⚙️  Chore (refactoring, build process, CI, etc.)
- [ ] 🧪 Test addition or update
- [ ] ⏪ Revert

## ✅ Checklist

- [ ] ~Added tests for new code.~ Not applicable, existing tests (here and in the `glrcfg` crate) cover this.
- [ ] CI is green, no warnings.
- [x] Code style visually aligns with the remainder of the codebase.
- [x] Comments are sensible and comprehensive.
- [x] Docs are up-to-date.
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] PR description is accurate and comprehensive.

## 📖 Additional Notes (if any)

Future TODO: find a better solution.

---

